### PR TITLE
prevent overscaling in popup.

### DIFF
--- a/flutter_win_2/lib/Widgets/goal_view.dart
+++ b/flutter_win_2/lib/Widgets/goal_view.dart
@@ -135,15 +135,23 @@ class _GoalViewState extends State<GoalView> {
                     textAlign: TextAlign.center,
                     style:
                         TextStyle(fontSize: 22.0, fontWeight: FontWeight.w600),
+                    textScaleFactor: 1.0,
                   ),
                   description: Text(
                     'In many ways, this reflection will be as important as what happened.',
                     textAlign: TextAlign.center,
                     style: TextStyle(fontSize: 18.0),
+                    textScaleFactor: 1.0,
                   ),
-                  buttonOkText: Text("Crushed it 😎"),
+                  buttonOkText: Text(
+                    "Crushed it 😎",
+                    textScaleFactor: 1.0,
+                  ),
                   buttonOkColor: appGreen,
-                  buttonCancelText: Text("Need Tweaks 🤔"),
+                  buttonCancelText: Text(
+                    "Need Tweaks 🤔",
+                    textScaleFactor: 1.0,
+                  ),
                   buttonCancelColor: appRed,
                   onOkButtonPressed: () {
                     Navigator.pop(context);


### PR DESCRIPTION
Before: 
![Simulator Screen Shot - iPhone 7 - 2020-10-17 at 17 27 29](https://user-images.githubusercontent.com/1642110/96333745-3f6e4300-109e-11eb-8fd4-6e98bc8d705b.png)

After:
![Simulator Screen Shot - iPhone 7 - 2020-10-17 at 17 26 58](https://user-images.githubusercontent.com/1642110/96333758-4bf29b80-109e-11eb-932e-88663d356840.png)

A more elegant solution may be needed if the app is to last